### PR TITLE
Reduced time complexity in baffle determination (__isGroupBaffle__)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -652,7 +652,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    salomeToOpenFOAM  Copyright (C) 2013  Nicolas Edh
+    salomeToOpenFOAM  Copyright (C) 2018  Nicolas Edh
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,6 @@ License
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with hexBlocker.  If not, see <http://www.gnu.org/licenses/>.
+    along with salomeToOpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
 
     The license is included in the file LICENSE.

--- a/salomeToOpenFOAM.py
+++ b/salomeToOpenFOAM.py
@@ -17,10 +17,12 @@ No sorting of faces is done so you'll have to run
 renumberMesh -overwrite
 In order to use the mesh.
 """
-#Copyright 2013
+#Copyright 2018
 #Author Nicolas Edh,
-#Nicolas.Edh@gmail.com,
-#or user "nsf" at cfd-online.com
+#Nicolas.Edh@gmail.com (user "nsf" at cfd-online.com)
+#Contributor(s):
+#   Sam Woodhead
+#   sam@blueforge.xyz
 #
 #License
 #
@@ -35,7 +37,7 @@ In order to use the mesh.
 #    GNU General Public License for more details.
 #
 #    You should have received a copy of the GNU General Public License
-#    along with hexBlocker.  If not, see <http://www.gnu.org/licenses/>.
+#    along with salomeToOpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
 #
 #    The license is included in the file LICENSE.
 #
@@ -131,7 +133,7 @@ def exportToFoam(mesh,dirname='polyMesh'):
     __debugPrint__('Counting number of faces:\n')
     #Filter faces
     filter=smesh.GetFilter(SMESH.EDGE,SMESH.FT_FreeFaces)
-    extFaces=mesh.GetIdsFromFilter(filter)
+    extFaces=set(mesh.GetIdsFromFilter(filter))
     nrBCfaces=len(extFaces)
     nrExtFaces=len(extFaces)
     #nrBCfaces=mesh.NbFaces();#number of bcfaces in Salome
@@ -189,7 +191,7 @@ def exportToFoam(mesh,dirname='polyMesh'):
                             "or more groups. One is : %s"  %(gr.GetName()))
 
             #if the group is a baffle then the faces should be added twice
-            if __isGroupBaffle__(mesh,gr,extFaces):
+            if __isGroupBaffle__(mesh,gr,extFaces,grIds):
                 nrBCfaces+=nr
                 nrFaces+=nr
                 nrIntFaces-=nr
@@ -611,8 +613,8 @@ def findSelectedMeshes():
     else:
         return meshes
 
-def __isGroupBaffle__(mesh,group,extFaces):
-    for sid in group.GetIDs():
+def __isGroupBaffle__(mesh,group,extFaces,grIds):
+    for sid in grIds:
         if not sid in extFaces:
             __debugPrint__("group %s is a baffle\n" %group.GetName(),1)
             return True


### PR DESCRIPTION
- Reduced time complexity of baffle determination [from O(n) to O(1)](https://wiki.python.org/moin/TimeComplexity) by converting the list return type of [GetIdsFromFilter](https://github.com/meritzio/salomeToOpenFOAM/blob/master/salomeToOpenFOAM.py#L136) into a set - which has constant time complexity. The reduction from linear time complexity should help reduce the overhead of particularly large mesh exports.

- An extra argument has been added to __isGroupBaffle__, to pass an already invoked [getIDs](https://github.com/meritzio/salomeToOpenFOAM/blob/master/salomeToOpenFOAM.py#L175) to remove a second API call to group.getIDs [within the for loop of __isGroupBaffle__](https://github.com/meritzio/salomeToOpenFOAM/blob/master/salomeToOpenFOAM.py#L617)

Changes to source have been validated by means of MD5 checksum of polyMesh outputs between the original scripts

- Updates to copyright date, corrected some referencing errors, added my name to list as contributor :)
